### PR TITLE
Add comprehensive MPS support across training and inference

### DIFF
--- a/GPT_SoVITS/BigVGAN/inference.py
+++ b/GPT_SoVITS/BigVGAN/inference.py
@@ -7,6 +7,7 @@ import os
 import argparse
 import json
 import torch
+from device_utils import is_mps_available, pick_device
 import librosa
 from utils import load_checkpoint
 from meldataset import get_mel_spectrogram
@@ -74,9 +75,9 @@ def main():
     global device
     if torch.cuda.is_available():
         torch.cuda.manual_seed(h.seed)
-        device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
+    device = pick_device()
+    if device.type == "mps" and is_mps_available():
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
     inference(a, h)
 

--- a/GPT_SoVITS/BigVGAN/inference_e2e.py
+++ b/GPT_SoVITS/BigVGAN/inference_e2e.py
@@ -9,6 +9,7 @@ import numpy as np
 import argparse
 import json
 import torch
+from device_utils import is_mps_available, pick_device
 from scipy.io.wavfile import write
 from env import AttrDict
 from meldataset import MAX_WAV_VALUE
@@ -89,9 +90,9 @@ def main():
     global device
     if torch.cuda.is_available():
         torch.cuda.manual_seed(h.seed)
-        device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
+    device = pick_device()
+    if device.type == "mps" and is_mps_available():
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
     inference(a, h)
 

--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import yaml
+from device_utils import device_supports_fp16, empty_cache, is_mps_available, pick_device
 from AR.models.t2s_lightning_module import Text2SemanticLightningModule
 from BigVGAN.bigvgan import BigVGAN
 from feature_extractor.cnhubert import CNHubert
@@ -203,13 +204,10 @@ def set_seed(seed: int):
         if torch.cuda.is_available():
             torch.cuda.manual_seed(seed)
             torch.cuda.manual_seed_all(seed)
-            # torch.backends.cudnn.deterministic = True
-            # torch.backends.cudnn.benchmark = False
-            # torch.backends.cudnn.enabled = True
-            # 开启后会影响精度
-            torch.backends.cuda.matmul.allow_tf32 = False
-            torch.backends.cudnn.allow_tf32 = False
-    except:
+            if torch.cuda.is_available():
+                torch.backends.cuda.matmul.allow_tf32 = False
+                torch.backends.cudnn.allow_tf32 = False
+    except Exception:
         pass
     return seed
 
@@ -309,15 +307,16 @@ class TTS_Config:
         self.configs: dict = configs_.get("custom", configs_["v2"])
         self.default_configs = deepcopy(configs_)
 
-        self.device = self.configs.get("device", torch.device("cpu"))
-        if "cuda" in str(self.device) and not torch.cuda.is_available():
-            print("Warning: CUDA is not available, set device to CPU.")
-            self.device = torch.device("cpu")
+        self.device = pick_device(self.configs.get("device"))
+        if self.device.type == "mps" and is_mps_available():
+            os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
         self.is_half = self.configs.get("is_half", False)
-        if str(self.device) == "cpu" and self.is_half:
-            print(f"Warning: Half precision is not supported on CPU, set is_half to False.")
+        if self.is_half and not device_supports_fp16(self.device):
+            print("Warning: Half precision is not supported on the selected device, set is_half to False.")
             self.is_half = False
+        self.configs.device = self.device
+        self.configs.is_half = self.is_half
 
         version = self.configs.get("version", None)
         self.version = version
@@ -1367,10 +1366,7 @@ class TTS:
     def empty_cache(self):
         try:
             gc.collect()  # 触发gc的垃圾回收。避免内存一直增长。
-            if "cuda" in str(self.configs.device):
-                torch.cuda.empty_cache()
-            elif str(self.configs.device) == "mps":
-                torch.mps.empty_cache()
+            empty_cache(self.device)
         except:
             pass
 

--- a/GPT_SoVITS/export_torch_script_v3v4.py
+++ b/GPT_SoVITS/export_torch_script_v3v4.py
@@ -22,12 +22,15 @@ from librosa.filters import mel as librosa_mel_fn
 
 
 from inference_webui import get_spepc, norm_spec, resample, ssl_model
+from device_utils import device_supports_fp16, is_mps_available, pick_device
 
 logging.config.dictConfig(uvicorn.config.LOGGING_CONFIG)
 logger = logging.getLogger("uvicorn")
 
-is_half = True
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+is_half = device_supports_fp16(device)
 now_dir = os.getcwd()
 
 

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -31,6 +31,7 @@ import warnings
 import torch
 import torchaudio
 from text.LangSegmenter import LangSegmenter
+from device_utils import device_supports_fp16, empty_cache, is_mps_available, pick_device
 
 logging.getLogger("markdown_it").setLevel(logging.ERROR)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
@@ -87,7 +88,11 @@ is_share = os.environ.get("is_share", "False")
 is_share = eval(is_share)
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 # is_half=False
 punctuation = set(["!", "?", "…", ",", ".", "-", " "])
 import gradio as gr
@@ -111,7 +116,8 @@ def set_seed(seed):
     os.environ["PYTHONHASHSEED"] = str(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
+    if device.type == "cuda" and torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
 
 
 # set_seed(42)
@@ -131,11 +137,6 @@ language = sys.argv[-1] if sys.argv[-1] in scan_language_list() else language
 i18n = I18nAuto(language=language)
 
 # os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 确保直接启动推理UI时也能够设置。
-
-if torch.cuda.is_available():
-    device = "cuda"
-else:
-    device = "cpu"
 
 dict_language_v1 = {
     i18n("中文"): "all_zh",  # 全部按中文识别
@@ -162,7 +163,7 @@ dict_language = dict_language_v1 if version == "v1" else dict_language_v2
 
 tokenizer = AutoTokenizer.from_pretrained(bert_path)
 bert_model = AutoModelForMaskedLM.from_pretrained(bert_path)
-if is_half == True:
+if is_half:
     bert_model = bert_model.half().to(device)
 else:
     bert_model = bert_model.to(device)
@@ -410,7 +411,7 @@ def clean_hifigan_model():
         hifigan_model = hifigan_model.cpu()
         hifigan_model = None
         try:
-            torch.cuda.empty_cache()
+            empty_cache(device)
         except:
             pass
 
@@ -421,7 +422,7 @@ def clean_bigvgan_model():
         bigvgan_model = bigvgan_model.cpu()
         bigvgan_model = None
         try:
-            torch.cuda.empty_cache()
+            empty_cache(device)
         except:
             pass
 
@@ -432,7 +433,7 @@ def clean_sv_cn_model():
         sv_cn_model.embedding_model = sv_cn_model.embedding_model.cpu()
         sv_cn_model = None
         try:
-            torch.cuda.empty_cache()
+            empty_cache(device)
         except:
             pass
 

--- a/GPT_SoVITS/inference_webui_fast.py
+++ b/GPT_SoVITS/inference_webui_fast.py
@@ -28,6 +28,7 @@ import re
 import sys
 
 import torch
+from device_utils import device_supports_fp16, is_mps_available, pick_device
 
 now_dir = os.getcwd()
 sys.path.append(now_dir)
@@ -49,7 +50,11 @@ is_share = eval(is_share)
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 gpt_path = os.environ.get("gpt_path", None)
 sovits_path = os.environ.get("sovits_path", None)
 cnhubert_base_path = os.environ.get("cnhubert_base_path", None)
@@ -70,12 +75,8 @@ i18n = I18nAuto(language=language)
 
 # os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 确保直接启动推理UI时也能够设置。
 
-if torch.cuda.is_available():
-    device = "cuda"
 # elif torch.backends.mps.is_available():
 #     device = "mps"
-else:
-    device = "cpu"
 
 # is_half = False
 # device = "cpu"

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -13,7 +13,13 @@ opt_dir = os.environ.get("opt_dir")
 bert_pretrained_dir = os.environ.get("bert_pretrained_dir")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+from device_utils import device_supports_fp16, is_mps_available, pick_device
+
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 version = os.environ.get("version", None)
 import traceback
 import os.path
@@ -48,12 +54,6 @@ if os.path.exists(txt_path) == False:
     bert_dir = "%s/3-bert" % (opt_dir)
     os.makedirs(opt_dir, exist_ok=True)
     os.makedirs(bert_dir, exist_ok=True)
-    if torch.cuda.is_available():
-        device = "cuda:0"
-    # elif torch.backends.mps.is_available():
-    #     device = "mps"
-    else:
-        device = "cpu"
     if os.path.exists(bert_pretrained_dir):
         ...
     else:

--- a/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
+++ b/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
@@ -16,7 +16,13 @@ opt_dir = os.environ.get("opt_dir")
 cnhubert.cnhubert_base_path = os.environ.get("cnhubert_base_dir")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+from device_utils import device_supports_fp16, is_mps_available, pick_device
+
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 
 import traceback
 import numpy as np
@@ -59,15 +65,9 @@ os.makedirs(wav32dir, exist_ok=True)
 
 maxx = 0.95
 alpha = 0.5
-if torch.cuda.is_available():
-    device = "cuda:0"
-# elif torch.backends.mps.is_available():
-#     device = "mps"
-else:
-    device = "cpu"
 model = cnhubert.get_model()
 # is_half=False
-if is_half == True:
+if is_half:
     model = model.half().to(device)
 else:
     model = model.to(device)

--- a/GPT_SoVITS/prepare_datasets/2-get-sv.py
+++ b/GPT_SoVITS/prepare_datasets/2-get-sv.py
@@ -15,7 +15,13 @@ opt_dir = os.environ.get("opt_dir")
 sv_path = os.environ.get("sv_path")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+from device_utils import device_supports_fp16, is_mps_available, pick_device
+
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 
 import traceback
 import torchaudio
@@ -47,12 +53,6 @@ os.makedirs(wav32dir, exist_ok=True)
 
 maxx = 0.95
 alpha = 0.5
-if torch.cuda.is_available():
-    device = "cuda:0"
-# elif torch.backends.mps.is_available():
-#     device = "mps"
-else:
-    device = "cpu"
 
 
 class SV:
@@ -63,16 +63,16 @@ class SV:
         embedding_model.eval()
         self.embedding_model = embedding_model
         self.res = torchaudio.transforms.Resample(32000, 16000).to(device)
-        if is_half == False:
-            self.embedding_model = self.embedding_model.to(device)
-        else:
+        if is_half:
             self.embedding_model = self.embedding_model.half().to(device)
+        else:
+            self.embedding_model = self.embedding_model.to(device)
         self.is_half = is_half
 
     def compute_embedding3(self, wav):  # (1,x)#-1~1
         with torch.no_grad():
             wav = self.res(wav)
-            if self.is_half == True:
+            if self.is_half:
                 wav = wav.half()
             feat = torch.stack(
                 [Kaldi.fbank(wav0.unsqueeze(0), num_mel_bins=80, sample_frequency=16000, dither=0) for wav0 in wav]

--- a/GPT_SoVITS/prepare_datasets/3-get-semantic.py
+++ b/GPT_SoVITS/prepare_datasets/3-get-semantic.py
@@ -28,7 +28,13 @@ else:
     version = "v3"
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+from device_utils import device_supports_fp16, is_mps_available, pick_device
+
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+is_half = eval(os.environ.get("is_half", "True")) and device_supports_fp16(device)
 import traceback
 import sys
 
@@ -59,12 +65,7 @@ semantic_path = "%s/6-name2semantic-%s.tsv" % (opt_dir, i_part)
 if os.path.exists(semantic_path) == False:
     os.makedirs(opt_dir, exist_ok=True)
 
-    if torch.cuda.is_available():
-        device = "cuda"
-    # elif torch.backends.mps.is_available():
-    #     device = "mps"
-    else:
-        device = "cpu"
+    active_device = device
     hps = utils.get_hparams_from_file(s2config_path)
     vq_model = SynthesizerTrn(
         hps.data.filter_length // 2 + 1,
@@ -73,10 +74,10 @@ if os.path.exists(semantic_path) == False:
         version=version,
         **hps.model,
     )
-    if is_half == True:
-        vq_model = vq_model.half().to(device)
+    if is_half:
+        vq_model = vq_model.half().to(active_device)
     else:
-        vq_model = vq_model.to(device)
+        vq_model = vq_model.to(active_device)
     vq_model.eval()
     # utils.load_checkpoint(utils.latest_checkpoint_path(hps.s2_ckpt_dir, "G_*.pth"), vq_model, None, True)
     # utils.load_checkpoint(pretrained_s2G, vq_model, None, True)
@@ -91,10 +92,10 @@ if os.path.exists(semantic_path) == False:
         if os.path.exists(hubert_path) == False:
             return
         ssl_content = torch.load(hubert_path, map_location="cpu")
-        if is_half == True:
-            ssl_content = ssl_content.half().to(device)
+        if is_half:
+            ssl_content = ssl_content.half().to(active_device)
         else:
-            ssl_content = ssl_content.to(device)
+            ssl_content = ssl_content.to(active_device)
         codes = vq_model.extract_latent(ssl_content)
         semantic = " ".join([str(i) for i in codes[0, 0, :].tolist()])
         lines.append("%s\t%s" % (wav_name, semantic))

--- a/GPT_SoVITS/s1_train.py
+++ b/GPT_SoVITS/s1_train.py
@@ -9,6 +9,7 @@ import platform
 from pathlib import Path
 
 import torch
+from device_utils import is_mps_available
 from AR.data.data_module import Text2SemanticDataModule
 from AR.models.t2s_lightning_module import Text2SemanticLightningModule
 from AR.utils.io import load_yaml_config
@@ -108,17 +109,20 @@ def main(args):
     logger = TensorBoardLogger(name=output_dir.stem, save_dir=output_dir)
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["USE_LIBUV"] = "0"
+    has_cuda = torch.cuda.is_available()
+    has_mps = is_mps_available()
+    accelerator = "gpu" if has_cuda else ("mps" if has_mps else "cpu")
     trainer: Trainer = Trainer(
         max_epochs=config["train"]["epochs"],
-        accelerator="gpu" if torch.cuda.is_available() else "cpu",
+        accelerator=accelerator,
         # val_check_interval=9999999999999999999999,###不要验证
         # check_val_every_n_epoch=None,
         limit_val_batches=0,
-        devices=-1 if torch.cuda.is_available() else 1,
+        devices=-1 if has_cuda else 1,
         benchmark=False,
         fast_dev_run=False,
         strategy=DDPStrategy(process_group_backend="nccl" if platform.system() != "Windows" else "gloo")
-        if torch.cuda.is_available()
+        if has_cuda
         else "auto",
         precision=config["train"]["precision"],
         logger=logger,

--- a/GPT_SoVITS/s2_train.py
+++ b/GPT_SoVITS/s2_train.py
@@ -18,6 +18,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
+from device_utils import device_supports_fp16, pick_device, is_mps_available
 
 logging.getLogger("matplotlib").setLevel(logging.INFO)
 logging.getLogger("h5py").setLevel(logging.INFO)
@@ -41,13 +42,18 @@ from process_ckpt import savee
 torch.backends.cudnn.benchmark = False
 torch.backends.cudnn.deterministic = False
 ###反正A100fp32更快，那试试tf32吧
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = True
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
 torch.set_float32_matmul_precision("medium")  # 最低精度但最快（也就快一丁点），对于结果造成不了影响
 # from config import pretrained_s2G,pretrained_s2D
 global_step = 0
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
-device = "cpu"  # cuda以外的设备，等mps优化后加入
+if not device_supports_fp16(device):
+    hps.train.fp16_run = False
 
 
 def main():

--- a/GPT_SoVITS/s2_train_v3.py
+++ b/GPT_SoVITS/s2_train_v3.py
@@ -17,6 +17,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
+from device_utils import device_supports_fp16, is_mps_available, pick_device
 
 logging.getLogger("matplotlib").setLevel(logging.INFO)
 logging.getLogger("h5py").setLevel(logging.INFO)
@@ -41,13 +42,18 @@ from process_ckpt import savee
 torch.backends.cudnn.benchmark = False
 torch.backends.cudnn.deterministic = False
 ###反正A100fp32更快，那试试tf32吧
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = True
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
 torch.set_float32_matmul_precision("medium")  # 最低精度但最快（也就快一丁点），对于结果造成不了影响
 # from config import pretrained_s2G,pretrained_s2D
 global_step = 0
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
-device = "cpu"  # cuda以外的设备，等mps优化后加入
+if not device_supports_fp16(device):
+    hps.train.fp16_run = False
 
 
 def main():

--- a/GPT_SoVITS/s2_train_v3_lora.py
+++ b/GPT_SoVITS/s2_train_v3_lora.py
@@ -17,6 +17,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
+from device_utils import device_supports_fp16, is_mps_available, pick_device
 
 logging.getLogger("matplotlib").setLevel(logging.INFO)
 logging.getLogger("h5py").setLevel(logging.INFO)
@@ -41,13 +42,20 @@ from process_ckpt import savee
 torch.backends.cudnn.benchmark = False
 torch.backends.cudnn.deterministic = False
 ###反正A100fp32更快，那试试tf32吧
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = True
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
 torch.set_float32_matmul_precision("medium")  # 最低精度但最快（也就快一丁点），对于结果造成不了影响
 # from config import pretrained_s2G,pretrained_s2D
 global_step = 0
 
-device = "cpu"  # cuda以外的设备，等mps优化后加入
+
+device = pick_device()
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+if not device_supports_fp16(device):
+    hps.train.fp16_run = False
 
 
 def main():

--- a/api.py
+++ b/api.py
@@ -172,6 +172,7 @@ from module.mel_processing import spectrogram_torch
 import config as global_config
 import logging
 import subprocess
+from device_utils import device_supports_fp16, empty_cache, is_mps_available, pick_device
 
 
 class DefaultRefer:
@@ -207,8 +208,8 @@ def clean_hifigan_model():
         hifigan_model = hifigan_model.cpu()
         hifigan_model = None
         try:
-            torch.cuda.empty_cache()
-        except:
+            empty_cache(device)
+        except Exception:
             pass
 
 
@@ -218,8 +219,8 @@ def clean_bigvgan_model():
         bigvgan_model = bigvgan_model.cpu()
         bigvgan_model = None
         try:
-            torch.cuda.empty_cache()
-        except:
+            empty_cache(device)
+        except Exception:
             pass
 
 
@@ -229,8 +230,8 @@ def clean_sv_cn_model():
         sv_cn_model.embedding_model = sv_cn_model.embedding_model.cpu()
         sv_cn_model = None
         try:
-            torch.cuda.empty_cache()
-        except:
+            empty_cache(device)
+        except Exception:
             pass
 
 
@@ -1195,7 +1196,7 @@ parser.add_argument("-g", "--gpt_path", type=str, default=g_config.gpt_path, hel
 parser.add_argument("-dr", "--default_refer_path", type=str, default="", help="默认参考音频路径")
 parser.add_argument("-dt", "--default_refer_text", type=str, default="", help="默认参考音频文本")
 parser.add_argument("-dl", "--default_refer_language", type=str, default="", help="默认参考音频语种")
-parser.add_argument("-d", "--device", type=str, default=g_config.infer_device, help="cuda / cpu")
+parser.add_argument("-d", "--device", type=str, default=g_config.infer_device, help="cuda / mps / cpu")
 parser.add_argument("-a", "--bind_addr", type=str, default="0.0.0.0", help="default: 0.0.0.0")
 parser.add_argument("-p", "--port", type=int, default=g_config.api_port, help="default: 9880")
 parser.add_argument(
@@ -1217,7 +1218,9 @@ parser.add_argument("-b", "--bert_path", type=str, default=g_config.bert_path, h
 args = parser.parse_args()
 sovits_path = args.sovits_path
 gpt_path = args.gpt_path
-device = args.device
+device = pick_device(args.device)
+if device.type == "mps" and is_mps_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 port = args.port
 host = args.bind_addr
 cnhubert_base_path = args.hubert_path
@@ -1252,6 +1255,9 @@ if args.half_precision:
     is_half = True
 if args.full_precision and args.half_precision:
     is_half = g_config.is_half  # 炒饭fallback
+if is_half and not device_supports_fp16(device):
+    logger.warning("当前设备不支持半精度, 自动切换为全精度")
+    is_half = False
 logger.info(f"半精: {is_half}")
 
 # 流式返回模式

--- a/config.py
+++ b/config.py
@@ -4,6 +4,8 @@ import sys
 
 import torch
 
+from device_utils import device_supports_fp16, is_mps_available
+
 from tools.i18n.i18n import I18nAuto
 
 i18n = I18nAuto(language=os.environ.get("language", "Auto"))
@@ -148,9 +150,9 @@ api_port = 9880
 # Thanks to the contribution of @Karasukaigan and @XXXXRT666
 def get_device_dtype_sm(idx: int) -> tuple[torch.device, torch.dtype, float, float]:
     cpu = torch.device("cpu")
-    cuda = torch.device(f"cuda:{idx}")
     if not torch.cuda.is_available():
         return cpu, torch.float32, 0.0, 0.0
+    cuda = torch.device(f"cuda:{idx}")
     device_idx = idx
     capability = torch.cuda.get_device_capability(device_idx)
     name = torch.cuda.get_device_name(device_idx)
@@ -171,20 +173,28 @@ def get_device_dtype_sm(idx: int) -> tuple[torch.device, torch.dtype, float, flo
 IS_GPU = True
 GPU_INFOS: list[str] = []
 GPU_INDEX: set[int] = set()
-GPU_COUNT = torch.cuda.device_count()
+GPU_COUNT = torch.cuda.device_count() if torch.cuda.is_available() else (1 if is_mps_available() else 0)
 CPU_INFO: str = "0\tCPU " + i18n("CPU训练,较慢")
 tmp: list[tuple[torch.device, torch.dtype, float, float]] = []
 memset: set[float] = set()
 
-for i in range(max(GPU_COUNT, 1)):
-    tmp.append(get_device_dtype_sm(i))
+if torch.cuda.is_available():
+    for i in range(max(GPU_COUNT, 1)):
+        tmp.append(get_device_dtype_sm(i))
+elif is_mps_available():
+    tmp.append((torch.device("mps"), torch.float32, 10.0, 24.0))
+else:
+    tmp.append((torch.device("cpu"), torch.float32, 0.0, 0.0))
 
 for j in tmp:
     device = j[0]
     memset.add(j[3])
-    if device.type != "cpu":
+    if device.type == "cuda":
         GPU_INFOS.append(f"{device.index}\t{torch.cuda.get_device_name(device.index)}")
         GPU_INDEX.add(device.index)
+    elif device.type == "mps":
+        GPU_INFOS.append("0\tApple MPS")
+        GPU_INDEX.add(0)
 
 if not GPU_INFOS:
     IS_GPU = False
@@ -192,7 +202,7 @@ if not GPU_INFOS:
     GPU_INDEX.add(0)
 
 infer_device = max(tmp, key=lambda x: (x[2], x[3]))[0]
-is_half = any(dtype == torch.float16 for _, dtype, _, _ in tmp)
+is_half = any(device_supports_fp16(device) and dtype == torch.float16 for device, dtype, _, _ in tmp)
 
 
 class Config:

--- a/device_utils.py
+++ b/device_utils.py
@@ -1,0 +1,46 @@
+import torch
+
+
+def is_mps_available() -> bool:
+    """Return True if the Metal backend is built and available."""
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is None:
+        return False
+    try:
+        return mps_backend.is_available()
+    except AttributeError:
+        return False
+
+
+def pick_device(preferred: str | torch.device | None = None) -> torch.device:
+    """Pick an appropriate torch.device respecting availability."""
+    if preferred is not None:
+        requested = str(preferred).strip().lower()
+        if requested.startswith("cuda") and torch.cuda.is_available():
+            return torch.device(requested)
+        if requested == "mps" and is_mps_available():
+            return torch.device("mps")
+        if requested == "cpu":
+            return torch.device("cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if is_mps_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def device_supports_fp16(device: torch.device) -> bool:
+    return device.type == "cuda"
+
+
+def empty_cache(device: torch.device) -> None:
+    if device.type == "cuda" and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif device.type == "mps" and is_mps_available():
+        try:
+            torch.mps.empty_cache()
+        except AttributeError:
+            pass
+
+
+__all__ = ["is_mps_available", "pick_device", "device_supports_fp16", "empty_cache"]

--- a/tools/asr/fasterwhisper_asr.py
+++ b/tools/asr/fasterwhisper_asr.py
@@ -4,6 +4,7 @@ import time
 import traceback
 
 import torch
+from device_utils import is_mps_available
 from faster_whisper import WhisperModel
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import LocalEntryNotFoundError
@@ -85,7 +86,12 @@ def execute_asr(input_folder, output_folder, model_path, language, precision):
     if language == "auto":
         language = None  # 不设置语种由模型自动输出概率最高的语种
     print("loading faster whisper model:", model_path, model_path)
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif is_mps_available():
+        device = "mps"
+    else:
+        device = "cpu"
     model = WhisperModel(model_path, device=device, compute_type=precision)
 
     input_file_names = os.listdir(input_folder)

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -14,6 +14,7 @@ import sys
 
 import ffmpeg
 import torch
+from device_utils import is_mps_available
 from bsroformer import Roformer_Loader
 from mdxnet import MDXNetDereverb
 from vr import AudioPre, AudioPreDeEcho
@@ -122,6 +123,11 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
         print("clean_empty_cache")
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif is_mps_available():
+            try:
+                torch.mps.empty_cache()
+            except AttributeError:
+                pass
     yield "\n".join(infos)
 
 


### PR DESCRIPTION
## Summary
- introduce a shared device utility to detect Metal support, pick execution devices, and clear accelerator caches
- rework training, dataset preparation, and inference entry points to honor MPS availability, disable half precision when required, and route tensors to the selected device
- update auxiliary tooling (BigVGAN inference, faster-whisper ASR, UVR web UI, export scripts) to respect the new device selection while keeping CUDA paths intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d76a99d54c832c891112fec709f3c4